### PR TITLE
Check if GDPR cookie consent is given before setting the pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Easily add Facebook Pixel to your Gatsby site. At this time, 'ViewContent' event is triggered via onRouteUpdate.
 
 ## Install
+
 `npm install --save gatsby-plugin-facebook-pixel`
 
 ## How to use
@@ -14,6 +15,9 @@ plugins: [
     resolve: `gatsby-plugin-facebook-pixel`,
     options: {
       pixelId: 'pixel id here',
+      // if you want to set the pixel only if GDPR consent is given
+      // implies a cookie is set with boolean value
+      cookieGDPR: 'cookie name here',
     },
   },
 ]

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import React from 'react'
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-  if (process.env.NODE_ENV === `production`) {
+  if (
+    process.env.NODE_ENV === `production` &&
+    (pluginOptions.cookieGDPR === undefined ||
+      document.cookie.indexOf(`${pluginOptions.cookieGDPR}=true`) >= 0)
+  ) {
     return setHeadComponents([
       <script
         key={`gatsby-plugin-facebook-pixel`}
@@ -17,6 +21,6 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
       `,
         }}
       />,
-    ]);
+    ])
   }
-};
+}


### PR DESCRIPTION
if an option `cookieGDPR` is set, we test if the cookie value in the browser is set to `true` before we add the tracking code

it doesn't cover more advanced settings (`cookieGDPR: {basic: true, analytics: true, ads: true}`) based GDPR cookies but its a good start :)

works out of the box with [react-cookie-banner](https://github.com/buildo/react-cookie-banner)