### PR TITLE
Don't inject Facebook Pixel if no provided pixelId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-facebook-pixel",
   "description": "Gatsby plugin to add facebook pixel onto a site",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Gabe Barrientos <gbscopet@gmail.com> (https://www.twitter.com/gabefromutah)",
   "devDependencies": {
     "babel-cli": "^6.24.1"

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
-  if (process.env.NODE_ENV === `production`) {
+  if (process.env.NODE_ENV === `production` && pluginOptions.pixelId) {
     return setHeadComponents([
       <script
         key={`gatsby-plugin-facebook-pixel`}


### PR DESCRIPTION
No reason for failed
```GET fbevents.js:25 GET https://connect.facebook.net/signals/config/undefined```
requests if you're testing production build but only provide Facebook Pixel ID on your server.